### PR TITLE
Increase _get_missing speed

### DIFF
--- a/pyseq.py
+++ b/pyseq.py
@@ -111,7 +111,6 @@ class Item(str):
         """
         return self.__path
 
-
     @property
     def name(self):
         """Item base name attribute
@@ -267,7 +266,6 @@ class Sequence(list):
 
         :return: Formatted string.
         """
-        
         format_char_types = {
             's': 'i',
             'e': 'i',
@@ -460,7 +458,7 @@ class Sequence(list):
         """
         return [f.frame for f in self if f.frame is not '']
 
-    def _get_missing(self):
+    def _get_missing_old(self):
         """looks for missing sequence indexes in sequence
         """
         if len(self) > 1:
@@ -471,6 +469,26 @@ class Sequence(list):
                 frange = range(self.start(), self.end())
             return filter(lambda x: x not in self.frames(), frange)
         return ''
+
+    def _get_missing(self):
+        """ looks for missing sequence indexes in sequence
+        """
+        missing = []
+        frames = self.frames()
+        if len(frames) == 0:
+            return missing
+        prev = frames[0]
+        index = 1
+        while index < len(frames):
+            diff = frames[index] - prev
+            if diff == 1:
+                prev = frames[index]
+                index += 1
+            else:
+                prev += 1
+                missing.append(prev)
+
+        return missing
 
 
 def diff(f1, f2):

--- a/tests/test_pyseq.py
+++ b/tests/test_pyseq.py
@@ -31,6 +31,8 @@
 # -----------------------------------------------------------------------------
 
 import os
+import re
+import random
 import unittest
 import subprocess
 from pyseq import Item, Sequence, diff, uncompress, getSequences
@@ -242,6 +244,41 @@ class SequenceTestCase(unittest.TestCase):
             seq.format('%h%4s-%4e%t'),
         )
 
+    def test__get_missing(self):
+        """ test that _get_missing works
+        """
+        # Can't initialize Sequence without an item
+        # seq = Sequence([])
+        # self.assertEqual(seq._get_missing(), [])
+
+        seq = Sequence(["file.00010.jpg"])
+        self.assertEqual(seq._get_missing(), [])
+
+        seq = Sequence(self.files)
+        seq.append("file.0006.jpg")
+        self.assertEqual(seq._get_missing(), [4, 5])
+
+        seq = Sequence(["file.%04d.jpg" % i for i in xrange(20)])
+        seq.pop(10)
+        seq.pop(10)
+        seq.pop(10)
+        seq.pop(14)
+        seq.pop(14)
+        missing = [10, 11, 12, 17, 18]
+        self.assertEqual(seq._get_missing(), missing)
+
+        missing = []
+        seq = Sequence(["file.0001.jpg"])
+        for i in xrange(2, 50):
+            if random.randint(0, 1) == 1:
+                seq.append("file.%04d.jpg" % i)
+            else:
+                missing.append(i)
+
+        # remove ending random frames
+        while missing[-1] > int(re.search("file\.(\d{4})\.jpg", seq[-1]).group(1)):
+            missing.pop(-1)
+        self.assertEqual(seq._get_missing(), missing)
 
 class HelperFunctionsTestCase(unittest.TestCase):
     """tests the helper functions like


### PR DESCRIPTION
Firstly, I love this thing.  I've used it at two or three facilities now, and it's very helpful.
However, I noticed that this can run a bit slow on a large number of files (reels of images not shots).  So, as an introduction I've made a newer Sequence._get_missing that runs much faster than the original.  I've renamed the previous one for testing purposes.  But here's a quick profiling of the two:

    import pyseq
    import random
    import cProfile
    frames = []
    # frame count of a 15 minutes at 24 fps
    frame_cnt = (5 * 60) * 24
    # create frames with some missing
    for i in xrange(frame_cnt):
        if random.randint(0, 100) <= 25:
            frames.append(i)

    seq = pyseq.Sequence(frames)
    # execute frames so it sets __frame before either test
    len(seq.frames())
    cProfile.run("seq._get_missing()")

12557 function calls (12556 primitive calls) in 0.014 seconds.....

    cProfile.run("seq._get_missing_old()")

71916 function calls (64725 primitive calls) in 8.229 seconds....

So, yeah, much faster.  My initial testing was on the frame equivalent of 90 minutes, but I got tired of waiting.
I have some other thoughts that I would like to bring to the table as well.