### PR TITLE
Speed ups

### DIFF
--- a/lss
+++ b/lss
@@ -168,7 +168,7 @@ Formatting options:
             items.extend(glob.glob(path))
 
     if options.recursive is None:
-        for seq in pyseq.iget_sequences(items):
+        for seq in pyseq.get_sequences(items):
             print(seq.format(options.format or pyseq.global_format))
     else:
         level = options.recursive

--- a/lss
+++ b/lss
@@ -161,7 +161,9 @@ Formatting options:
     items = []
     for path in args:
         if os.path.isdir(path):
-            items.extend(glob.glob(os.path.join(path, "*")))
+            join = os.path.join
+            items = [join(path, x) for x in os.listdir(path)]
+            # items.extend(glob.glob(os.path.join(path, "*")))
         else:
             items.extend(glob.glob(path))
 

--- a/lss
+++ b/lss
@@ -30,13 +30,15 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 
+import cProfile
 import os
 import sys
 import glob
 import pyseq
 import logging
 import optparse
-
+import pstats
+import StringIO
 
 def tree(source, level, seq_format):
     """Recusrively walk from the source and display all the the folders and
@@ -141,6 +143,8 @@ Formatting options:
         default=False, help="set logging level to debug (or $PYSEQ_LOG_LEVEL)")
     parser.add_option("-r", "--recursive", dest="recursive", action="callback",
         callback=_recur_cb, help="Walks the entire directory structure.")
+    parser.add_option("-p", "--profile", dest="profile", action="store_true",
+        default=False, help="Runs with a profiler.")
     (options, args) = parser.parse_args()
 
     if options.debug:
@@ -148,6 +152,11 @@ Formatting options:
 
     if len(args) == 0:
         args = [os.getcwd()]
+
+    prof = None
+    if options.profile is True:
+        prof = cProfile.Profile()
+        prof.enable()
 
     items = []
     for path in args:
@@ -166,6 +175,13 @@ Formatting options:
             if not os.path.isdir(path):
                 continue
             tree(path, level, options.format or "%h%r%t")
+
+    if prof is not None:
+        prof.disable()
+        s = StringIO.StringIO()
+        ps = pstats.Stats(prof, stream=s).sort_stats("cumulative")
+        ps.print_stats()
+        print s.getvalue()
 
     return 0
 

--- a/lss
+++ b/lss
@@ -161,12 +161,12 @@ Formatting options:
     items = []
     for path in args:
         if os.path.isdir(path):
-            items.extend(os.listdir(path))
+            items.extend(glob.glob(os.path.join(path, "*")))
         else:
             items.extend(glob.glob(path))
 
     if options.recursive is None:
-        for seq in pyseq.get_sequences(items):
+        for seq in pyseq.iget_sequences(items):
             print(seq.format(options.format or pyseq.global_format))
     else:
         level = options.recursive

--- a/pyseq.py
+++ b/pyseq.py
@@ -255,6 +255,8 @@ class Item(str):
 
     @property
     def stat(self):
+        """ Returns the os.stat object for this file.
+        """
         if self.__stat is None:
             self.__stat = os.stat(self.__path)
         return self.__stat
@@ -349,7 +351,7 @@ class Sequence(list):
             'e': self.end,
             'f': self.frames,
             'm': self.missing,
-            'd': lambda x: self.size,
+            'd': lambda *x: self.size,
             'p': self._get_padding,
             'r': functools.partial(self._get_framerange, missing=False),
             'R': functools.partial(self._get_framerange, missing=True),

--- a/pyseq.py
+++ b/pyseq.py
@@ -167,7 +167,7 @@ class Item(str):
         self.frame = None
         self.head = self.name
         self.tail = ''
-        self.pad = 0
+        self.pad = None
 
     def __eq__(self, other):
         return self.path == other.path
@@ -675,6 +675,8 @@ class Sequence(list):
         """:return: padding string, e.g. %07d"""
         try:
             pad = self[0].pad
+            if pad is None:
+                return ""
             # pad = len(self._get_frames()[0].pad)
             if pad < 2:
                 return '%d'
@@ -692,29 +694,30 @@ class Sequence(list):
         frange = []
         start = ''
         end = ''
+        frames = self.frames()
 
         if not missing:
-            if self.frames():
+            if frames:
                 return '%s-%s' % (self.start(), self.end())
             else:
                 return ''
 
-        if not self.frames():
+        if not frames:
             return ''
 
-        for i in range(0, len(self.frames())):
-            if int(self.frames()[i]) != int(
-                    self.frames()[i - 1]) + 1 and i != 0:
+        for i in range(0, len(frames)):
+            frame = frames[i]
+            if i != 0 and frame != frames[i - 1] + 1:
                 if start != end:
                     frange.append('%s-%s' % (str(start), str(end)))
                 elif start == end:
                     frange.append(str(start))
-                start = end = self.frames()[i]
+                start = end = frame
                 continue
-            if start is '' or int(start) > int(self.frames()[i]):
-                start = self.frames()[i]
-            if end is '' or int(end) < int(self.frames()[i]):
-                end = self.frames()[i]
+            if start is '' or int(start) > frame:
+                start = frame
+            if end is '' or int(end) < frame:
+                end = frame
         if start == end:
             frange.append(str(start))
         else:

--- a/pyseq.py
+++ b/pyseq.py
@@ -152,16 +152,7 @@ class Item(str):
         self.__dirname, self.__filename = os.path.split(self.__path)
         self.__digits = digits_re.findall(self.name)
         self.__parts = digits_re.split(self.name)
-        self.__size = 0
-        self.__mtime = 0
-        try:
-            stat = os.stat(self.__path)
-        except OSError as err:
-            if err.errno != 2:
-                pass
-        else:
-            self.__size = stat.st_size
-            self.__mtime = stat.st_mtime
+        self.__stat = None
 
         # modified by self.is_sibling()
         self.frame = None
@@ -236,13 +227,19 @@ class Item(str):
     def size(self):
         """Returns the size of the Item, reported by os.stat
         """
-        return self.__size
+        return self.stat.st_size
 
     @property
     def mtime(self):
         """Returns the modification time of the Item
         """
-        return self.__mtime
+        return self.stat.st_mtime
+
+    @property
+    def stat(self):
+        if self.__stat is None:
+            self.__stat = os.stat(self.__path)
+        return self.__stat
 
     @deprecated
     def isSibling(self, item):

--- a/pyseq.py
+++ b/pyseq.py
@@ -1094,7 +1094,8 @@ def iget_sequences(source):
         items = source
     elif isinstance(source, str):
         if os.path.isdir(source):
-            items = iglob(os.path.join(source, "*"))
+            join = os.path.join
+            items = [join(source, x) for x in os.listdir(source)]
         else:
             items = iglob(source)
     else:


### PR DESCRIPTION
This started out as just making a generator version of get_sequences but turned into some significant speed increases.  When the sequences are small the speed increase is small but noticeable:
```
$ time python lss tests/files/
...
real    0m0.101s
user    0m0.009s
sys 0m0.080s
```
Vs
```
$ time python lss tests/files/
...
real    0m0.087s
user    0m0.007s
sys 0m0.069s
```

But when you're doing a very large sequence:
```
$ time python lss /path/to/big/tiff_seq_01/
4974 pic_seq.%08d.tiff [1-4974]
real    1m5.045s
user    1m2.482s
sys 0m2.201s
```
Vs
```
$ time python lss /path/to/big/tiff_seq_01/
4974 pic_seq.%08d.tiff [1-4974]
real    0m1.319s
user    0m0.177s
sys 0m1.110s
```
The increase is very noticeable.

Firstly, I added a 'iget_sequences' which is a generator version of get_sequences.  It sorts the files with a version of natural sort that moves the file extensions to the head.  So the order of the sequences comes out differently.  With the test files it doesn't run any faster, but I suspect that if you were to use it on a large number of various sequences there'd be a speed increase.

Secondly, I added a profiler to lss.  I did this mainly to find what could use some work, but I left it in there cause it's helpful.

Next, I decreased some of the os calls and used listdir instead of glob, as listdir is faster.  I also converted Item.__size, and Item.__mtime to be lazy properties.  The values aren't collected on init, but is pulled from an os.stat when requested.  This change could be debatable as it just puts off the slowness of getting the values to a later time.

There are three big changes:

- Item.frame is now an int and there's a Item.pad attribute.  There was only one time where frame was being used as a string, all the other times it was being cast to an int.

- Sequence.frames() was being called a lot in _get_framerange, I switched it over to be called once and I saw some decent speed increases.

- Sequence.__attrs__ was calculating values that might not be used.  Instead I turned the dict into a mapping of format directive to callable.  Then when Sequence.format uses it, it only executes the callable once, and replaces the callable with a value.  This also sped things up.

Let me know if you find any issues, or if you have questions.
