### PR TITLE
String comparison

### DIFF
--- a/pyseq.py
+++ b/pyseq.py
@@ -1047,7 +1047,7 @@ def get_sequences(source):
     if isinstance(source, list):
         items = sorted(source, key=lambda x: str(x))
 
-    elif isinstance(source, str):
+    elif isinstance(source, basestring):
         if os.path.isdir(source):
             items = sorted(glob(os.path.join(source, '*')))
         else:


### PR DESCRIPTION
This is a tiny change but it's been bugging me lately.  Usually when you're testing if a variable is of string type you use basestring.  That way it will catch unicode strings.

```
>>> s = "something"
>>> isinstance(s, basestring)
True
>>> s = u"something"
>>> isinstance(s, basestring)
True
>>> isinstance(s, str)
False
```