### PR TITLE
Adding directory format attribute

### DIFF
--- a/lss
+++ b/lss
@@ -43,8 +43,12 @@ def tree(source, level, seq_format):
     sequences.
     """
 
-    blue = "\033[94m"
-    endc = "\033[0m"
+    if sys.stdout.isatty():
+        blue = "\033[94m"
+        endc = "\033[0m"
+    else:
+        blue = ""
+        endc = ""
     ends = {}
     done = []
 
@@ -91,6 +95,7 @@ def tree(source, level, seq_format):
                 print "".join([sp, "└── ", seq.format(seq_format)])
             else:
                 print "".join([sp, "├── ", seq.format(seq_format)])
+    print endc
 
 
 def _recur_cb(option, opt_str, value, parser):

--- a/tests/test_pyseq.py
+++ b/tests/test_pyseq.py
@@ -369,6 +369,15 @@ class SequenceTestCase(unittest.TestCase):
             'file.%04d.jpg 1-10 (missing [4-5, 7-9])'
         )
 
+    def test_format_directory_attribute(self):
+        dir_name = os.path.dirname(
+            os.path.abspath(self.files[0])) + os.sep
+        seq = Sequence(self.files)
+        self.assertEqual(
+            seq.format("%D"),
+            dir_name
+            )
+
     def test__get_missing(self):
         """ test that _get_missing works
         """


### PR DESCRIPTION
I just noticed that there's no formatting attribute for the parent directory of a sequence.  I've added one here.  When uncompressing it ignores the %D attribute since it's gotten straight away.

This also fixes #32 since it was really quick.

And I noticed that Sequence consumes the given list.  I'm not sure if that's intended, but I stopped it from doing that by making a copy of the list.