### PR TITLE
Speed ups to format and uncompress

### DIFF
--- a/pyseq.py
+++ b/pyseq.py
@@ -128,6 +128,14 @@ def _ext_key(x):
     return [ext] + _natural_key(name)
 
 
+def _get_format_framerange(range_func, frames_func, missing):
+    """ This function is used to call Sequence._get_framerange without needing
+    to any other functions within Sequence.__attrs__.  It delays calling any
+    functions until the frame range is actually requested
+    """
+    return range_func(frames_func(), missing)
+
+
 def natural_sort(items):
     return sorted(items, key=_natural_key)
 
@@ -356,12 +364,18 @@ class Sequence(list):
             'e': self.end,
             'f': self.frames,
             'm': self.missing,
-            'M': functools.partial(self._get_framerange, self.missing(), missing=True),
+            'M': functools.partial(
+                _get_format_framerange, self._get_framerange,
+                self.missing, True),
             'd': lambda *x: self.size,
             'D': self.directory,
             'p': self._get_padding,
-            'r': functools.partial(self._get_framerange, self.frames(), missing=False),
-            'R': functools.partial(self._get_framerange, self.frames(), missing=True),
+            'r': functools.partial(
+                _get_format_framerange, self._get_framerange,
+                self.frames, False),
+            'R': functools.partial(
+                _get_format_framerange, self._get_framerange,
+                self.frames, True),
             'h': self.head,
             't': self.tail
         }

--- a/pyseq.py
+++ b/pyseq.py
@@ -55,7 +55,9 @@ import warnings
 import functools
 from glob import glob
 from glob import iglob
+from itertools import groupby
 from datetime import datetime
+from operator import itemgetter
 
 __version__ = "0.5.0"
 
@@ -728,8 +730,6 @@ class Sequence(list):
         :return: formatted frame range string.
         """
         frange = []
-        start = ''
-        end = ''
         if not missing:
             if frames:
                 return '%s-%s' % (self.start(), self.end())
@@ -739,23 +739,13 @@ class Sequence(list):
         if not frames:
             return ''
 
-        for i in range(0, len(frames)):
-            frame = frames[i]
-            if i != 0 and frame != frames[i - 1] + 1:
-                if start != end:
-                    frange.append('%s-%s' % (str(start), str(end)))
-                elif start == end:
-                    frange.append(str(start))
-                start = end = frame
-                continue
-            if start is '' or int(start) > frame:
-                start = frame
-            if end is '' or int(end) < frame:
-                end = frame
-        if start == end:
-            frange.append(str(start))
-        else:
-            frange.append('%s-%s' % (str(start), str(end)))
+        for _, group in groupby(enumerate(frames), lambda (a, b): a - b):
+            group = map(itemgetter(1), group)
+            if len(group) > 1:
+                frange.append("%d-%d" % (group[0], group[-1]))
+            else:
+                frange.append(str(group[0]))
+
         return "[%s]" % range_join.join(frange)
 
     def _get_frames(self):

--- a/pyseq.py
+++ b/pyseq.py
@@ -955,31 +955,28 @@ def uncompress(seq_string, fmt=global_format):
     except IndexError:
         pass
 
-    items = []
-    if missing:
-        for i in range(int(s), int(e) + 1):
-            if i in missing:
-                continue
-            f = pad % i
-            name = '%s%s%s' % (
-                match.groupdict().get('h', ''), f, 
-                match.groupdict().get('t', '')
-            )
-            items.append(Item(os.path.join(dirname, name)))
+    seq = None
+    while len(missing) > 0:
+        m = missing.pop(0)
+        try:
+            frames.remove(m)
+        except IndexError:
+            pass
 
-    else:
-        for i in frames:
-            f = pad % i
-            name = '%s%s%s' % (
-                match.groupdict().get('h', ''), f, 
-                match.groupdict().get('t', '')
+    grp_dict = match.groupdict()
+    for i in frames:
+        name = "%s%s%s" % (
+            grp_dict.get("h", ""),
+            pad % i,
+            grp_dict.get("t", "")
             )
-            items.append(Item(os.path.join(dirname, name)))
+        item = Item(os.path.join(dirname, name))
+        if seq is None:
+            seq = Sequence([item])
+        else:
+            seq.append(item)
 
-    seqs = get_sequences(items)
-    if seqs:
-        return seqs[0]
-    return seqs
+    return seq or []
 
 
 @deprecated


### PR DESCRIPTION
I've added a couple little changes that seem to speed a couple cases up for me.  However, I've run out of ways to speed up format, and uncompress.  When using small numbers of frames it's not a problem but, my use cases handle tens of thousands of frames.  At that scale there's some serious slow downs.

I've adjusted how _get_framerange generates the 'broken' frame ranges.  Using the groupby method seems to cause improved speed.

__attrs__ was calling functionality that wasn't necessarily needed which caused some slow downs.  Now everything in __attrs__ is only executed when the attribute is used in format.

Instead of uncompress generating a list of Items and sending them to get_sequences, I've created a Sequence and appended the items to it.  There might be some argument about this.  But it does speed up the function.  I also changed the way missing frames are handled.  Now they are simply removed from the frames list.  I did a couple minor organizations to this function as well.

As a side note, I did a quick test of of using cython to staticly type the uncompress function and got some pretty good increases.