### PR TITLE
Add number property to frame item.

### DIFF
--- a/pyseq.py
+++ b/pyseq.py
@@ -174,6 +174,7 @@ class Item(str):
             self.__path = os.path.abspath(str(item))
         self.__dirname, self.__filename = os.path.split(self.__path)
         self.__digits = digits_re.findall(self.name)
+        self.__number = int(self.__digits[-1])
         self.__parts = digits_re.split(self.name)
         self.__stat = None
 
@@ -233,6 +234,12 @@ class Item(str):
         """Numerical components of item name.
         """
         return self.__digits
+
+    @property
+    def number(self):
+        """The frame number of the item.
+        """
+        return self.__number
 
     @property
     def parts(self):

--- a/pyseq.py
+++ b/pyseq.py
@@ -174,7 +174,10 @@ class Item(str):
             self.__path = os.path.abspath(str(item))
         self.__dirname, self.__filename = os.path.split(self.__path)
         self.__digits = digits_re.findall(self.name)
-        self.__number = int(self.__digits[-1])
+        if self.__digits:
+            self.__number = int(self.__digits[-1])
+        else:
+            self.__number = None
         self.__parts = digits_re.split(self.name)
         self.__stat = None
 


### PR DESCRIPTION
When looping through frames in a sequence, it would be useful to have access to the current frame number. This pull request adds a "number" property to the Item class which would allow access to this.