### PR TITLE
Issue 57

### DIFF
--- a/pyseq.py
+++ b/pyseq.py
@@ -489,8 +489,8 @@ class Sequence(list):
                 fmt_char = format_char_types[var]
             except KeyError as err:
                 raise FormatError("Bad directive: %%%s" % var)
-            _old = '%s%s' % (pad or '', var)
-            _new = '(%s)%s%s' % (var, pad or '', fmt_char)
+            _old = '%%%s%s' % (pad or '', var)
+            _new = '%%(%s)%s%s' % (var, pad or '', fmt_char)
             fmt = fmt.replace(_old, _new)
             val = atts[var]
             # only execute the callable once, just in case

--- a/tests/test_pyseq.py
+++ b/tests/test_pyseq.py
@@ -369,6 +369,16 @@ class SequenceTestCase(unittest.TestCase):
             'file.%04d.jpg 1-10 (missing [4-5, 7-9])'
         )
 
+    def test_format_is_working_properly_4(self):
+        """testing if format is working properly
+        """
+        seq = Sequence(self.files)
+        seq.append('file.0006.jpg')
+        self.assertEqual(
+            seq.format('%h%s%t'),
+            'file.1.jpg'
+        )
+
     def test_format_directory_attribute(self):
         dir_name = os.path.dirname(
             os.path.abspath(self.files[0])) + os.sep


### PR DESCRIPTION
Fix for sequence.format not being able to use %s for start frame unless used as the first character (issue #57)