### PR TITLE
addresses issue #64, bumps version to 0.5.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,10 +2,22 @@
 CHANGELOG
 =========
 
+v0.5.4
+======
+
+* Fixes setup issues for python 2.7
+
+v0.5.3
+======
+
+* Fixes bug where changes in frame size (e.g. 9 to 10) cause incorrect pad
+
+* Disables strict padding in lss by default (adds --strict option)
+
 v0.5.1
 ======
 
-* adds %M (missing frames) and %D (parent dir) directives
+* Adds %M (missing frames) and %D (parent dir) directives
 
 * lss to only use colors when stdout is tty
 

--- a/pyseq.py
+++ b/pyseq.py
@@ -57,7 +57,7 @@ from glob import glob
 from glob import iglob
 from datetime import datetime
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 # default serialization format string
 global_format = '%4l %h%p%t %R'

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2011-2020 Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (C) 2011-2021 Ryan Galloway (ryan@rsgalloway.com)
 #
 # This module is part of Shotman and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 
 from distutils.core import setup
 from pyseq import __version__
+
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.rst')) as f:
+    long_description = f.read()
+
 setup(
     name='pyseq',
     version=__version__,
-    description='Compressed Sequence Python Module',
+    description='Compressed Sequence String Module',
+    long_description=long_description,
+    long_description_content_type='text/x-rst',
     author='Ryan Galloway',
     author_email='ryan@rsgalloway.com',
     url='http://github.com/rsgalloway/pyseq',


### PR DESCRIPTION
Changes:

- addresses issue #64
- bumps version to 0.5.4
- unit tests pass

before on python2.7:

`TypeError: 'encoding' is an invalid keyword argument for this function
`

With this update, running python setup.py install completes successfully. 

The version bump also addresses the pypi issue reported [here](https://github.com/rsgalloway/pyseq/issues/64#issuecomment-809822102).
