### PR TITLE
Remove deprecation warnings

### DIFF
--- a/pyseq.py
+++ b/pyseq.py
@@ -87,9 +87,6 @@ log = logging.getLogger('pyseq')
 log.addHandler(logging.StreamHandler())
 log.setLevel(int(os.environ.get('PYSEQ_LOG_LEVEL', logging.INFO)))
 
-# show deprecationWarnings in 2.7+
-warnings.simplefilter('always', DeprecationWarning)
-
 # python 3 strings
 try:
     unicode = unicode


### PR DESCRIPTION
Hey, so I'm encountering the same issue as this forum post:
https://www.sidefx.com/forum/topic/69691/?page=1#post-296264

I was wondering if you would be open to removing this warnings filter or putting it behind an env var? It's difficult when using this package in conjunction with third party apps like houdini.

Thanks in advance!