### PR TITLE
better handling of sequences with many missing frames

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 CHANGELOG
 =========
 
-v0.5.6
+v0.6.0
 ======
 
 * Fixes issue #67 (hangs on many missing frames)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+v0.5.6
+======
+
+* Fixes issue #67 (hangs on many missing frames)
+
 v0.5.5
 ======
 

--- a/pyseq.py
+++ b/pyseq.py
@@ -57,7 +57,7 @@ from glob import glob
 from glob import iglob
 from datetime import datetime
 
-__version__ = "0.5.6"
+__version__ = "0.6.0"
 
 # default serialization format string
 global_format = '%4l %h%p%t %R'
@@ -780,10 +780,11 @@ class Sequence(list):
         """
         return [f.frame for f in self if f.frame is not None]
 
-    def _get_missing(self, max_size=10000):
+    def _get_missing(self, max_size=100000):
         """looks for missing sequence indexes in sequence
 
-        :param max_size: max sequence size before using ranges
+        :param max_size: maximum missing frame sequence size for
+            returning explcit frames, otherwise use ranges
         :return: List of missing frames, or ranges of frames if
             sequence size is greater than max_size
         """
@@ -800,7 +801,7 @@ class Sequence(list):
             # this can be expensive with large lists (high memory)
             return sorted(list(set(frames).symmetric_difference(r)))
         else:
-            log.debug("frame range is large")
+            log.debug("frame range is large, using ranges")
             for i, f in enumerate(frames[:-1]):
                 missing.append(range(f+1, frames[i+1]))
             return missing

--- a/pyseq.py
+++ b/pyseq.py
@@ -57,7 +57,7 @@ from glob import glob
 from glob import iglob
 from datetime import datetime
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 # default serialization format string
 global_format = '%4l %h%p%t %R'
@@ -754,7 +754,11 @@ class Sequence(list):
 
         for i in range(0, len(frames)):
             frame = frames[i]
-            if i != 0 and frame != frames[i - 1] + 1:
+            if type(frame) == range:
+                frange.append('%s-%s' % (frame[0], frame[-1]))
+                continue
+            prev = frames[i - 1]
+            if i != 0 and frame != prev + 1:
                 if start != end:
                     frange.append('%s-%s' % (str(start), str(end)))
                 elif start == end:
@@ -776,20 +780,30 @@ class Sequence(list):
         """
         return [f.frame for f in self if f.frame is not None]
 
-    def _get_missing(self):
-        """Looks for missing sequence indexes in sequence
+    def _get_missing(self, max_size=10000):
+        """looks for missing sequence indexes in sequence
 
-        .. todo:: change this to:
-            r = range(frames[0], frames[-1] + 1)
-            return sorted(list(set(frames).symmetric_difference(r)))
+        :param max_size: max sequence size before using ranges
+        :return: List of missing frames, or ranges of frames if
+            sequence size is greater than max_size
         """
         missing = []
         frames = self.frames()
+
         if len(frames) == 0:
             return missing
+        elif len(frames) == 1:
+            return frames
 
         r = range(frames[0], frames[-1] + 1)
-        return sorted(list(set(frames).symmetric_difference(r)))
+        if len(r) <= max_size:
+            # this can be expensive with large lists (high memory)
+            return sorted(list(set(frames).symmetric_difference(r)))
+        else:
+            log.debug("frame range is large")
+            for i, f in enumerate(frames[:-1]):
+                missing.append(range(f+1, frames[i+1]))
+            return missing
 
 
 def diff(f1, f2):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2011-2021 Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2011-2022 Ryan Galloway (ryan@rsgalloway.com)
 #
 # This module is part of Shotman and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php


### PR DESCRIPTION
Currently, pyseq could hang if it encounters a sequence with many (millions) of missing frames, or random files that mimic sequences where the gap in frames is large (>1M). The issue is in _get_missing() and eats lots of memory. 

See issue #67 and test_issue_67 in the unit tests for examples.

The issue is easily reproducible, e.g.:

```
>>> seqs = get_sequences(["image-00000001.jpg", "image-50000000.jpg"])
>>> print(seqs)
```

The solution here addresses this problem by setting an upper limit on frame sequence sizes to 100K when calculating missing frames (which I would assume would handle >99.9% of use cases: 100K frames is >1 hour). 

Sequences with more than 100K frames will now return range values instead of explicit frame number when calculating missing frames. This seems to work fine when printing compressed sequence strings, 

```
>>> print(get_sequences(["image.001.jpg", "image.100.jpg"])[0].format("%M"))
[2-99]
>>> print(get_sequences(["image.0000001.jpg", "image.1000000.jpg"])[0].format("%M"))
[2-999999, ]
```

but since the return type could be different in these cases I bumped the minor version. 
